### PR TITLE
feat(router): add replace arg for navigate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.workingDirectories": [{ "mode": "auto" }]
+}

--- a/docs/website/docs/hooks.md
+++ b/docs/website/docs/hooks.md
@@ -284,6 +284,19 @@ function SomeComponent() {
     );
 }
 ```
+And you can pass `replace` value as a third argument. It will replace current path in history.
+
+```jsx
+function SomeComponent() {
+    const { navigate } = useRouter();
+
+    return (
+        <ButtonGroup>
+            <Button onClick={() => navigate('/user', { id: 123 }, true)}>Go to User</Button>
+        </ButtonGroup>
+    );
+}
+```
 #### activePath
 > Current route path.
 

--- a/packages/urban-bot/src/components/Router/Router.tsx
+++ b/packages/urban-bot/src/components/Router/Router.tsx
@@ -20,8 +20,8 @@ export function Router({ children, withInitializeCommands = false, historyLength
     const childrenArray = Children.toArray(children) as ReactElement<RouteProps>[];
 
     const navigate: Navigate = useCallback(
-        (path: string, query = {}) => {
-            const newHistory = [...history.current, path];
+        (path: string, query = {}, replace = false) => {
+            const newHistory = [...(replace ? history.current.slice(0, -1) : history.current), path];
 
             history.current = newHistory.length <= historyLength ? newHistory : newHistory.slice(1);
 

--- a/packages/urban-bot/src/context.ts
+++ b/packages/urban-bot/src/context.ts
@@ -17,7 +17,7 @@ export function getBotContext<Bot extends UrbanBot = UrbanBot, BotType extends U
 }
 
 export type RouterQuery = Record<string, any>;
-export type Navigate<Q = RouterQuery> = (name: string, query?: Q) => void;
+export type Navigate<Q = RouterQuery> = (name: string, query?: Q, replace?: boolean) => void;
 
 export type RouterContext<P extends object = {}, Q = RouterQuery> = {
     navigate: Navigate<Q>;


### PR DESCRIPTION
### Description
This PR adds a `replace` argument for the `navigate` function. It behaves like the standard `replace` argument in the History API.

### Additional
- Add information about `replace` in documentation.
- Add VS Code workspace configuration for ESLint.
